### PR TITLE
Use a temporary buffer for NPP color conversion

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -43,12 +43,12 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
   }
 }
 
-void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream) {
+void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream) {
   int step = w * 3;
   NppiSize size;
   size.height = h;
   size.width = w;
-  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size, GetNppContext(stream)));
+  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(in, step, out, step, size, GetNppContext(stream)));
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -171,7 +171,7 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   kernels::copy<StorageType, StorageCPU>(output_buffer, decoded.get(), volume(shape), stream);
 }
 
-void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream);
+void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream);
 
 }  // namespace dali
 

--- a/dali/operators/image/color/color_space_conversion.h
+++ b/dali/operators/image/color/color_space_conversion.h
@@ -43,6 +43,8 @@ class ColorSpaceConversion : public Operator<Backend> {
 
   const DALIImageType input_type_;
   const DALIImageType output_type_;
+
+  Tensor<Backend> scratch_;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in the usage of NPP color conversion functions which do not support in-place processing.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Changed usage of NPP color space conversion functions to avoid passing the same input and output buffer*
 - Affected modules and functionalities:
     *ColorSpaceConversion op, ImageDecoder*
 - Key points relevant for the review:
     *Usage of temporary buffers.*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2003]*
